### PR TITLE
Use Ember.get in Object Proxy

### DIFF
--- a/addon/proxies/object.js
+++ b/addon/proxies/object.js
@@ -4,22 +4,24 @@ import Record from 'ember-time-machine/-private/Record';
 import { wrapValue, unwrapValue } from 'ember-time-machine/utils/value';
 import { pathInGlobs } from 'ember-time-machine/utils/utils';
 
+const { get } = Ember;
+
 export default Ember.ObjectProxy.extend(RecordKeeperMixin, {
   unknownProperty(key) {
     return wrapValue(this, key, this._super(...arguments));
   },
 
   setUnknownProperty(key, value) {
-    let content = this.get('content');
-    let state = this.get('_rootMachineState');
-    let path = this.get('_path');
+    let content = get(this, 'content');
+    let state = get(this, '_rootMachineState');
+    let path = get(this, '_path');
 
-    if (state && !pathInGlobs(path.concat(key).join('.'), state.get('frozenProperties'))) {
+    if (state && !pathInGlobs(path.concat(key).join('.'), get(state, 'frozenProperties'))) {
       this._addRecord(new Record({
         target: content,
         path,
         key,
-        before: content.get(key),
+        before: get(content, key),
         after: value
       }));
 


### PR DESCRIPTION
This allows the use of POJOs. 

I ran into an issue, when one of the properties of my model is a plain JS object, it of course didn't respond to `.get`. 
Using the functional version of get allowed actioning on a POJO.
The `get` in question is: `before: get(content, key),`. I replace the other instances of get in the file for consistency.